### PR TITLE
Artifacts temporarily moved to io.narayana to be published

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+target/
+
+# Eclipse
+.project
+.settings/
+.checkstyle
+.classpath

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,9 +19,9 @@
 
     <parent>
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
-        <groupId>org.eclipse.microprofile.lra</groupId>
+        <groupId>io.narayana.microprofile.lra</groupId>
         <artifactId>microprofile-lra-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.0.1.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-lra-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.microprofile.lra</groupId>
+    <groupId>io.narayana.microprofile.lra</groupId>
     <artifactId>microprofile-lra-parent</artifactId>
     <name>MicroProfile Long Running Actions</name>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.0.1.Final-SNAPSHOT</version>
     <description>Eclipse MicroProfile LRA Feature - Parent POM</description>
     <packaging>pom</packaging>
 

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -18,12 +18,11 @@
 
     <parent>
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
-        <groupId>org.eclipse.microprofile.lra</groupId>
+        <groupId>io.narayana.microprofile.lra</groupId>
         <artifactId>microprofile-lra-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.0.1.Final-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.eclipse.microprofile.lra</groupId>
     <artifactId>microprofile-lra-spec</artifactId>
     <packaging>pom</packaging>
     <name>MicroProfile LRA Specification</name>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -18,9 +18,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.microprofile.lra</groupId>
+        <groupId>io.narayana.microprofile.lra</groupId>
         <artifactId>microprofile-lra-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.0.1.Final-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -41,7 +41,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.microprofile.lra</groupId>
+            <groupId>io.narayana.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>


### PR DESCRIPTION
this change is meant to be temporar until the eclipse foundation
accept the proposal. Up to that time we need to publish
the proposal as maven Final artifact to be possible depend on it.

@mmusgrov : I'm proposing changeset based on the discussion at https://github.com/jbosstm/narayana/pull/1326#issuecomment-391977862. Let me know if you consider that differently. If this is accepted I plan to publish 0.0.1.Final as artifacts and move here to 0.0.2.Final-SNAPSHOT. Then the changes in narayana and quickstarts will follow.